### PR TITLE
Fixed Try monad which fails in the exception case on Methods which do…

### DIFF
--- a/CSharpMonad.UnitTests/CSharpMonad.UnitTests.csproj
+++ b/CSharpMonad.UnitTests/CSharpMonad.UnitTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="src\Combined.cs" />
     <Compile Include="src\ReaderTests.cs" />
     <Compile Include="src\StateTests.cs" />
+    <Compile Include="src\TryTests.cs" />
     <Compile Include="src\WriterTests.cs" />
     <Compile Include="src\ReaderWriterStateTests.cs" />
   </ItemGroup>
@@ -92,7 +93,8 @@
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\xunit.core.2.0.0-rc1-build2826\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0-rc1-build2826\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
   </Target>
-  <UsingTask AssemblyFile="..\packages\xunit.runners.2.0.0-rc1-build2826\tools\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit"></UsingTask>
+  <UsingTask AssemblyFile="..\packages\xunit.runners.2.0.0-rc1-build2826\tools\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit">
+  </UsingTask>
   <Target Name="Test" DependsOnTargets="Build">
     <xunit Assemblies="$(OutputPath)\$(AssemblyName).dll" />
   </Target>

--- a/CSharpMonad.UnitTests/src/TryTests.cs
+++ b/CSharpMonad.UnitTests/src/TryTests.cs
@@ -1,0 +1,188 @@
+////////////////////////////////////////////////////////////////////////////////////////
+// The MIT License (MIT)
+// 
+// Copyright (c) 2014 Martin Thomalla
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+using System;
+using Xunit;
+using Monad;
+
+namespace Monad.UnitTests
+{
+    public class TryTests
+    {
+        [Fact]
+        public void TestTry()
+        {
+            var r = from lhs in Error()
+                    from rhs in Two()
+                    select lhs+rhs;
+
+            Assert.True(r().IsFaulted && r().Exception.Message == "Error!!");
+        }
+
+        [Fact]
+        public void TestEitherBinding2()
+        {
+            var r = (from lhs in Two()
+                     from rhs in Error()
+                     select lhs + rhs)
+                    .TryMemo();
+
+            Assert.True(r().IsFaulted && r().Exception.Message == "Error!!");
+        }
+
+
+        [Fact]
+        public void TestEitherBinding3()
+        {
+            var r = 
+                from lhs in Two()
+                select lhs;
+
+            Assert.True(r().Value == 2);
+        }    
+
+        [Fact]
+        public void TestEitherBinding4()
+        {
+            var r = 
+                from lhs in Error()
+                select lhs;
+
+            Assert.True(r().IsFaulted && r().Exception.Message == "Error!!");
+        }
+
+        [Fact]
+        public void TestEitherBinding5()
+        {
+            var r =
+                from one in Two()
+                from two in Error()
+                from thr in Two()
+                select one + two + thr;
+
+            Assert.True(r().IsFaulted && r().Exception.Message == "Error!!");
+        }
+
+        [Fact]
+        public void TestEitherMatch1()
+        {
+            var unit =
+                (from one in Two()
+                 from two in Error()
+                 from thr in Two()
+                 select one + two + thr)
+                .Match(
+                    Success: r => Assert.True(false),
+                    Fail: l => Assert.True(l.Message == "Error!!")
+                );
+
+            Console.WriteLine(unit.ToString());
+        }
+
+        [Fact]
+        public void TestEitherMatch2()
+        {
+            var unit =
+                (from one in Two()
+                 from two in Error()
+                 from thr in Two()
+                 select one + two + thr)
+                .Match(
+                    succ => Assert.False(true),
+                    fail => Assert.True(fail.Message == "Error!!")
+                );
+            Console.WriteLine(unit.ToString());
+        }
+
+        [Fact]
+        public void TestEitherMatch3()
+        {
+            var unit =
+                (from one in Two()
+                 from two in Two()
+                 select one + two)
+                .Match(
+                    Success: r => Assert.True(r == 4),
+                    Fail: l => Assert.False(true)
+                );
+            Console.WriteLine(unit.ToString());
+        }
+
+        [Fact]
+        public void TestEitherMatch4()
+        {
+            var unit =
+                (from one in Two()
+                 from two in Two()
+                 select one + two)
+                .Match(
+                    succ => Assert.True(succ == 4),
+                    fail => Assert.False(true)
+                );
+            Console.WriteLine(unit.ToString());
+        }
+
+        [Fact]
+        public void TestEitherMatch5()
+        {
+            var result =
+                (from one in Two()
+                 from two in Two()
+                 select one + two)
+                .Match(
+                    Success: r => r * 2,
+                    Fail: l => 0
+                );
+
+            Assert.True(result() == 8);
+        }
+
+        [Fact]
+        public void TestEitherMatch6()
+        {
+            var result =
+                (from one in Two()
+                 from err in Error()
+                 from two in Two()
+                 select one + two)
+                .Match(
+                    Success: r => r * 2,
+                    Fail: l => 0
+                );
+
+            Assert.True(result() == 0);
+        }
+
+        public Try<int> Two()
+        {
+            return () => 2;
+        }
+
+        public Try<int> Error()
+        {
+            return () => { throw new Exception("Error!!"); };
+        }
+
+    }
+}

--- a/CSharpMonad/src/Try.cs
+++ b/CSharpMonad/src/Try.cs
@@ -1,4 +1,4 @@
-﻿////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
 // The MIT License (MIT)
 // 
 // Copyright (c) 2014 Paul Louth
@@ -260,7 +260,7 @@ namespace Monad
         /// </returns>
         public static IEnumerable<T> AsEnumerable<T>(this Try<T> self)
         {
-            var res = self();
+            var res = self.Try();
             if (res.IsFaulted)
                 yield break;
             else
@@ -276,7 +276,7 @@ namespace Monad
         /// </returns>
         public static IEnumerable<T> AsEnumerableInfinite<T>(this Try<T> self)
         {
-            var res = self();
+            var res = self.Try();
             if (res.IsFaulted)
                 yield break;
             else
@@ -370,7 +370,7 @@ namespace Monad
 
             return () =>
             {
-                var res = self();
+                var res = self.Try();
                 return res.IsFaulted
                     ? Fail(res.Exception)
                     : Success(res.Value);
@@ -386,7 +386,7 @@ namespace Monad
 
             return () =>
             {
-                var res = self();
+                var res = self.Try();
                 return res.IsFaulted
                     ? default(R)
                     : Success(res.Value);
@@ -403,7 +403,7 @@ namespace Monad
 
             return () =>
             {
-                var res = self();
+                var res = self.Try();
 
                 if (res.IsFaulted)
                     Fail(res.Exception);
@@ -423,7 +423,7 @@ namespace Monad
 
             return () =>
             {
-                var res = self();
+                var res = self.Try();
                 if (!res.IsFaulted)
                     Success(res.Value);
                 return Unit.Default;


### PR DESCRIPTION
… not wrap the call to self() in a try-catch block. Replaced self() with self.Try() in these methods.